### PR TITLE
发布casbin配置文件

### DIFF
--- a/src/CasbinServiceProvider.php
+++ b/src/CasbinServiceProvider.php
@@ -17,6 +17,7 @@ class CasbinServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([__DIR__.'/../database/migrations' => database_path('migrations')], 'laravel-casbin-migrations');
             $this->publishes([__DIR__.'/../config/casbin-basic-model.conf' => config_path('casbin-basic-model.conf')], 'config');
+            $this->publishes([__DIR__.'/../config/casbin.php' => config_path('casbin.php')], 'config');
         }
     }
 


### PR DESCRIPTION
发布至config目录  有助于提高用户配置的自由度